### PR TITLE
Support blocks in callbacks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,12 @@ source 'https://rubygems.org'
 gemspec
 
 rails_version = ENV.fetch('RAILS_VERSION') { 'default' }
+
 case rails_version
 when "default"
   gem "rails", "~> 3.2"
 else
   gem "rails", "~> #{rails_version}"
 end
+
 gem "rack-test"

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ when "default"
 else
   gem "rails", "~> #{rails_version}"
 end
+gem "rack-test"

--- a/Rakefile
+++ b/Rakefile
@@ -2,19 +2,19 @@
 
 require "bundler/gem_tasks"
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 desc "Run specs"
 RSpec::Core::RakeTask.new do |t|
-  t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
+  t.pattern = "./spec/**/*_spec.rb" # don"t need this, it's default.
   # Put spec opts in a file named .rspec in root
 end
 
 desc "Generate code coverage"
 RSpec::Core::RakeTask.new(:coverage) do |t|
-  t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
+  t.pattern = "./spec/**/*_spec.rb" # don"t need this, it's default.
   t.rcov = true
-  t.rcov_opts = ['--exclude', 'spec']
+  t.rcov_opts = ["--exclude", "spec"]
 end
 
 desc "Run the specs"

--- a/Rakefile
+++ b/Rakefile
@@ -6,13 +6,13 @@ require "rspec/core/rake_task"
 
 desc "Run specs"
 RSpec::Core::RakeTask.new do |t|
-  t.pattern = "./spec/**/*_spec.rb" # don"t need this, it's default.
+  t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
   # Put spec opts in a file named .rspec in root
 end
 
 desc "Generate code coverage"
 RSpec::Core::RakeTask.new(:coverage) do |t|
-  t.pattern = "./spec/**/*_spec.rb" # don"t need this, it's default.
+  t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
   t.rcov = true
   t.rcov_opts = ["--exclude", "spec"]
 end

--- a/lib/active_async/callbacks.rb
+++ b/lib/active_async/callbacks.rb
@@ -9,8 +9,8 @@ module ActiveAsync
           class_eval <<-RUBY
             define_callbacks :async_#{callback_name}
 
-            def self.#{callback_name}_with_async(*methods)
-              #{callback_name}_without_async(*extract_async_methods(methods))
+            def self.#{callback_name}_with_async(*methods, &block)
+              #{callback_name}_without_async(*extract_async_methods(methods), &block)
             end
 
             class << self

--- a/spec/active_async/active_record_spec.rb
+++ b/spec/active_async/active_record_spec.rb
@@ -25,4 +25,15 @@ describe ActiveAsync::ActiveRecord do
       Blog.create
     end
   end
+
+  context "synchronous callbacks" do
+    it "doesn't prevent synchronous callbacks to be called" do
+      expect(blog).to receive(:cheap_save_from_block)
+      expect(blog).to receive(:cheap_save_from_lambda)
+      expect(blog).to receive(:cheap_save_from_method_name)
+
+      blog.save
+    end
+  end
+
 end

--- a/spec/active_async/active_record_spec.rb
+++ b/spec/active_async/active_record_spec.rb
@@ -26,7 +26,7 @@ describe ActiveAsync::ActiveRecord do
     end
   end
 
-  context "synchronous callbacks" do
+  context "synchronous callbacks", :stub_resque do
     it "doesn't prevent synchronous callbacks to be called" do
       expect(blog).to receive(:cheap_save_from_block)
       expect(blog).to receive(:cheap_save_from_lambda)

--- a/spec/active_async/callbacks_spec.rb
+++ b/spec/active_async/callbacks_spec.rb
@@ -108,7 +108,6 @@ describe ActiveAsync::Callbacks do
         end
       end
 
-
     end
   end
 

--- a/spec/dummy/app/models/blog.rb
+++ b/spec/dummy/app/models/blog.rb
@@ -3,8 +3,18 @@ class Blog < ActiveRecord::Base
   after_update  :expensive_update_method, :async => true
   after_save    :expensive_save_method,   :async => true
 
+  after_save { cheap_save_from_block }
+  after_save ->{ cheap_save_from_lambda }
+  after_save :cheap_save_from_method_name
+
+  # "normal" synchronous callbacks
+
   def self.run_expensive_method; end
   def expensive_save_method; self.class.run_expensive_method; end
   def expensive_create_method; self.class.run_expensive_method; end
   def expensive_update_method; self.class.run_expensive_method; end
+
+  def cheap_save_from_block; end
+  def cheap_save_from_lambda; end
+  def cheap_save_from_method_name; end
 end


### PR DESCRIPTION
Hi ChallengePost,

It looks like overriding activerecord's callbacks was ignoring the possibility to use a block, and it got lost in when calling the original (non-async) callback. 

This PR addresses that.