### PR TITLE
Don't break by requiring resque prematurely

### DIFF
--- a/lib/active_async.rb
+++ b/lib/active_async.rb
@@ -1,4 +1,3 @@
-require "resque"
 require "active_support/concern"
 require "active_async/version"
 require "active_async/async"

--- a/lib/active_async/version.rb
+++ b/lib/active_async/version.rb
@@ -1,3 +1,3 @@
 module ActiveAsync
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Hi!

It appears that the Resque adapter already requires `resque`, so there's no reason to do it in the main module definition. 

I made a PR with a fix that is working for me. 🦄 